### PR TITLE
Change reference from deprecated wpApiOptions to WP_API_Settings.root

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -182,7 +182,7 @@
         var Comments = Backbone.Collection.extend({
             model: Comment,
             url: function() {
-                return wpApiOptions.base + '/posts/' + this.post.id + '/comments';
+                return WP_API_Settings.root + '/posts/' + this.post.id + '/comments';
             },
 
             comparator: function(comment) {


### PR DESCRIPTION
Based on a change to the JSON REST API plugin (https://github.com/WP-API/WP-API/pull/321),
we now need to reference WP_API_Settings.root which now is responsible for rendering the home directory and the wpjson subdirectory. Otherwise, you get a 'wpApiOptions is not defined' error, which is currently happening on the theme's demo site on the single post view:
http://demo.wedevs.com/backbone/#/posts/1/hello-world/. 
