### PR TITLE
BootStrap Nav Walker Class Updated

### DIFF
--- a/lib/bootstrap-walker.php
+++ b/lib/bootstrap-walker.php
@@ -2,7 +2,7 @@
 
 class Bootstrap_Walker_Nav_Menu extends Walker_Nav_Menu {
 
-    function start_lvl( &$output, $depth ) {
+    function start_lvl( &$output, $depth = 0, $args = array() ) {
 
         $indent = str_repeat( "\t", $depth );
 


### PR DESCRIPTION
The `Bootstrap_Walker_Nav_Menu` class was to old. That's why the theme was throwing this 
`Strict standards: Declaration of Bootstrap_Walker_Nav_Menu::start_lvl() should be compatible with Walker_Nav_Menu::start_lvl(&$output, $depth = 0, $args = Array) in /var/www/rashedun.me/web/app/themes/wp-backbone/lib/bootstrap-walker.php on line 96
` strict standard error. Now it's fixed and the class is updated.
